### PR TITLE
update to nushell 0.84.1 + new record api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,6 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
@@ -773,9 +767,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e649f36136c4c61131ea2b0e051df1e27e040e2859150b9efa2d1e79d4b66651"
+version = "0.84.1"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -786,15 +778,11 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5c8c24d7bab232b594d4052536bc21c689ce7bdf38e1fd499fcfbf537007c0"
+version = "0.84.1"
 
 [[package]]
 name = "nu-path"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040af52fc60c443c6e6f45ac3bcd1a47faf8e7ca33bb852609f8581a5020749f"
+version = "0.84.1"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -803,9 +791,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e483640dafc2d0866a4f54b142806dc62d17cea604a9af59a8f2ff95c018e44"
+version = "0.84.1"
 dependencies = [
  "bincode",
  "nu-engine",
@@ -817,9 +803,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5ff85113e603b4f17ca68657ddb37f9be1fd250011e2c50d03e26081e2d48c"
+version = "0.84.1"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -838,9 +822,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cb7efdaad0b3530a72b2d9e8b4d3f2c24a6217e5f313fdd589d77f5fe02a91"
+version = "0.84.1"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -868,7 +850,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "itoa",
 ]
 
@@ -1226,9 +1208,9 @@ checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]
@@ -1450,11 +1432,10 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vte"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
 dependencies = [
- "arrayvec 0.5.2",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.3.3",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -512,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +591,12 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -596,13 +648,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a53088c87cf71c9d4f3372a2cb9eea1e7b8a0b1bf8b7f7d23fe5b76dbb07e63b"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -634,10 +697,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fba61dbe003b79fe1af52ff15a489e50b9e66b36c79f945fbcbcf02e895f26d"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "line-wrap"
@@ -653,6 +743,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -682,6 +778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7015a04103ad78abb77e4b79ed151e767922d1cfde5f62640471c629a2320d"
 dependencies = [
  "nu-ansi-term 0.49.0",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -730,12 +835,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -773,7 +905,6 @@ dependencies = [
  "nu-path",
  "nu-protocol",
  "nu-utils",
- "sysinfo",
 ]
 
 [[package]]
@@ -812,12 +943,31 @@ dependencies = [
  "indexmap 2.0.0",
  "lru",
  "miette",
+ "nu-path",
+ "nu-system",
  "nu-utils",
  "num-format",
  "serde",
  "serde_json",
  "thiserror",
  "typetag",
+]
+
+[[package]]
+name = "nu-system"
+version = "0.84.1"
+dependencies = [
+ "chrono",
+ "libc",
+ "libproc",
+ "log",
+ "mach2",
+ "nix",
+ "ntapi",
+ "once_cell",
+ "procfs",
+ "sysinfo",
+ "winapi",
 ]
 
 [[package]]
@@ -935,6 +1085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1117,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "rustix 0.36.15",
 ]
 
 [[package]]
@@ -1106,6 +1277,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.36.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1305,7 @@ dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1193,6 +1384,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "smawk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["nu", "plugin", "syntax", "highlighting"]
 categories = ["command-line-utilities", "development-tools", "value-formatting"]
 
 [dependencies]
+#nu
 nu-plugin = { version = "0.84.1", path = "../nushell/crates/nu-plugin" }
 nu-protocol = { version = "0.84.1", path = "../nushell/crates/nu-protocol" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,8 @@ keywords = ["nu", "plugin", "syntax", "highlighting"]
 categories = ["command-line-utilities", "development-tools", "value-formatting"]
 
 [dependencies]
-# nu
-nu-plugin = "0.83"
-nu-protocol = "0.83"
+nu-plugin = { version = "0.84.1", path = "../nushell/crates/nu-plugin" }
+nu-protocol = { version = "0.84.1", path = "../nushell/crates/nu-protocol" }
 
 # highlighting
 syntect = "5"

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,13 +25,13 @@ impl Plugin for HighlightPlugin {
             .optional(
                 "language",
                 SyntaxShape::String,
-                "language or file extension to help language detection"
+                "language or file extension to help language detection",
             )
             .named(
                 "theme",
                 SyntaxShape::String,
                 "theme used for highlighting",
-                Some('t')
+                Some('t'),
             )
             .switch("list-themes", "list all possible themes", None)
             .category(Category::Strings)
@@ -49,26 +49,26 @@ impl Plugin for HighlightPlugin {
                         (String::from("name"), Type::String),
                         (String::from("author"), Type::String),
                         (String::from("default"), Type::Bool),
-                    ])
+                    ]),
                 ),
             ])
             .plugin_examples(
                 (vec![
                     (
                         "Highlight a toml file by its file extension",
-                        "open Cargo.toml -r | highlight toml"
+                        "open Cargo.toml -r | highlight toml",
                     ),
                     (
                         "Highlight a rust file by programming language",
-                        "open src/main.rs | highlight Rust"
+                        "open src/main.rs | highlight Rust",
                     ),
                     (
                         "Highlight a bash script by inferring the language (needs shebang)",
-                        "open example.sh | highlight"
+                        "open example.sh | highlight",
                     ),
                     (
                         "Highlight a toml file with another theme",
-                        "open Cargo.toml -r | highlight toml -t ansi"
+                        "open Cargo.toml -r | highlight toml -t ansi",
                     ),
                     ("List all available themes", "highlight --list-themes"),
                 ])
@@ -76,9 +76,9 @@ impl Plugin for HighlightPlugin {
                 .map(|(description, example)| PluginExample {
                     example: example.to_owned(),
                     description: description.to_owned(),
-                    result: None
+                    result: None,
                 })
-                .collect()
+                .collect(),
             )]
     }
 
@@ -86,7 +86,7 @@ impl Plugin for HighlightPlugin {
         &mut self,
         name: &str,
         call: &EvaluatedCall,
-        input: &Value
+        input: &Value,
     ) -> Result<Value, LabeledError> {
         assert_eq!(name, "highlight");
         let highlighter = Highlighter::new();
@@ -103,14 +103,14 @@ impl Plugin for HighlightPlugin {
                 return Err(LabeledError {
                     label: "Unknown theme, use `highlight --list-themes` to list all themes".into(),
                     msg: "unknown theme".into(),
-                    span: Some(span)
+                    span: Some(span),
                 })
             }
             (Some(v), _) => {
                 return Err(LabeledError {
                     label: "Expected theme value to be a string".into(),
                     msg: format!("expected string, got {}", v.get_type()),
-                    span: Some(v.expect_span())
+                    span: Some(v.span()),
                 })
             }
             (_, Some(t)) if highlighter.is_valid_theme(&t) => Some(t),
@@ -118,10 +118,10 @@ impl Plugin for HighlightPlugin {
                 return Err(LabeledError {
                     label: format!("Unknown theme \"{}\"", t),
                     msg: "use `highlight --list-themes` to list all themes".into(),
-                    span: None
+                    span: None,
                 })
             }
-            _ => None
+            _ => None,
         };
 
         // check whether to use true colors from env variable, default to true
@@ -136,8 +136,8 @@ impl Plugin for HighlightPlugin {
                         "consider unsetting $env.{} or set it to \"true\" or \"false\"",
                         TRUE_COLORS_ENV
                     ),
-                    span: None
-                })
+                    span: None,
+                }),
             })
             .unwrap_or(Ok(true))?;
 
@@ -149,13 +149,13 @@ impl Plugin for HighlightPlugin {
         let ret_val = match input {
             Value::String { val, .. } => Value::string(
                 highlighter.highlight(val, &language, &theme, true_colors),
-                call.head
+                call.head,
             ),
             v => {
                 return Err(LabeledError {
                     label: "Expected source code as string from pipeline".into(),
                     msg: format!("expected string, got {}", v.get_type()),
-                    span: Some(call.head)
+                    span: Some(call.head),
                 });
             }
         };

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,9 @@
-use crate::highlight::Highlighter;
+use std::env;
+
 use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{Category, PluginExample, PluginSignature, Spanned, SyntaxShape, Type, Value};
-use std::env;
+
+use crate::highlight::Highlighter;
 
 const THEME_ENV: &str = "NU_PLUGIN_HIGHLIGHT_THEME";
 const TRUE_COLORS_ENV: &str = "NU_PLUGIN_HIGHLIGHT_TRUE_COLORS";
@@ -23,13 +25,13 @@ impl Plugin for HighlightPlugin {
             .optional(
                 "language",
                 SyntaxShape::String,
-                "language or file extension to help language detection",
+                "language or file extension to help language detection"
             )
             .named(
                 "theme",
                 SyntaxShape::String,
                 "theme used for highlighting",
-                Some('t'),
+                Some('t')
             )
             .switch("list-themes", "list all possible themes", None)
             .category(Category::Strings)
@@ -47,26 +49,26 @@ impl Plugin for HighlightPlugin {
                         (String::from("name"), Type::String),
                         (String::from("author"), Type::String),
                         (String::from("default"), Type::Bool),
-                    ]),
+                    ])
                 ),
             ])
             .plugin_examples(
                 (vec![
                     (
                         "Highlight a toml file by its file extension",
-                        "open Cargo.toml -r | highlight toml",
+                        "open Cargo.toml -r | highlight toml"
                     ),
                     (
                         "Highlight a rust file by programming language",
-                        "open src/main.rs | highlight Rust",
+                        "open src/main.rs | highlight Rust"
                     ),
                     (
                         "Highlight a bash script by inferring the language (needs shebang)",
-                        "open example.sh | highlight",
+                        "open example.sh | highlight"
                     ),
                     (
                         "Highlight a toml file with another theme",
-                        "open Cargo.toml -r | highlight toml -t ansi",
+                        "open Cargo.toml -r | highlight toml -t ansi"
                     ),
                     ("List all available themes", "highlight --list-themes"),
                 ])
@@ -74,9 +76,9 @@ impl Plugin for HighlightPlugin {
                 .map(|(description, example)| PluginExample {
                     example: example.to_owned(),
                     description: description.to_owned(),
-                    result: None,
+                    result: None
                 })
-                .collect(),
+                .collect()
             )]
     }
 
@@ -84,7 +86,7 @@ impl Plugin for HighlightPlugin {
         &mut self,
         name: &str,
         call: &EvaluatedCall,
-        input: &Value,
+        input: &Value
     ) -> Result<Value, LabeledError> {
         assert_eq!(name, "highlight");
         let highlighter = Highlighter::new();
@@ -96,7 +98,7 @@ impl Plugin for HighlightPlugin {
         let theme_name = call.get_flag_value("theme");
         let theme_span = match &theme_name {
             Some(t) => t.span(),
-            None => call.head,
+            None => call.head
         };
         // use theme from environment variable if available, override with passed
         let theme = match (theme_name, env::var(THEME_ENV).ok()) {
@@ -105,14 +107,14 @@ impl Plugin for HighlightPlugin {
                 return Err(LabeledError {
                     label: "Unknown theme, use `highlight --list-themes` to list all themes".into(),
                     msg: "unknown theme".into(),
-                    span: Some(theme_span),
+                    span: Some(theme_span)
                 })
             }
             (Some(v), _) => {
                 return Err(LabeledError {
                     label: "Expected theme value to be a string".into(),
                     msg: format!("expected string, got {}", v.get_type()),
-                    span: Some(v.span()),
+                    span: Some(v.span())
                 })
             }
             (_, Some(t)) if highlighter.is_valid_theme(&t) => Some(t),
@@ -120,10 +122,10 @@ impl Plugin for HighlightPlugin {
                 return Err(LabeledError {
                     label: format!("Unknown theme \"{}\"", t),
                     msg: "use `highlight --list-themes` to list all themes".into(),
-                    span: None,
+                    span: None
                 })
             }
-            _ => None,
+            _ => None
         };
 
         // check whether to use true colors from env variable, default to true
@@ -138,8 +140,8 @@ impl Plugin for HighlightPlugin {
                         "consider unsetting $env.{} or set it to \"true\" or \"false\"",
                         TRUE_COLORS_ENV
                     ),
-                    span: None,
-                }),
+                    span: None
+                })
             })
             .unwrap_or(Ok(true))?;
 
@@ -151,13 +153,13 @@ impl Plugin for HighlightPlugin {
         let ret_val = match input {
             Value::String { val, .. } => Value::string(
                 highlighter.highlight(val, &language, &theme, true_colors),
-                call.head,
+                call.head
             ),
             v => {
                 return Err(LabeledError {
                     label: "Expected source code as string from pipeline".into(),
                     msg: format!("expected string, got {}", v.get_type()),
-                    span: Some(call.head),
+                    span: Some(call.head)
                 });
             }
         };

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,11 +1,11 @@
-use nu_protocol::{Span, Value};
+use nu_protocol::{record, Span, Value};
 
 /// Description of a theme.
 pub struct ThemeDescription {
     pub id: String,
     pub name: Option<String>,
     pub author: Option<String>,
-    pub default: bool
+    pub default: bool,
 }
 
 /// List of theme descriptions.
@@ -17,28 +17,23 @@ impl From<ThemeDescription> for Value {
             id,
             name,
             author,
-            default
+            default,
         } = value;
         Value::record(
-            vec![
-                String::from("id"),
-                String::from("name"),
-                String::from("author"),
-                String::from("default"),
-            ],
-            vec![
-                Value::string(id, Span::unknown()),
-                match name {
+            record! {
+                "id" => Value::string(id, Span::unknown()),
+                "name" => match name {
                     Some(name) => Value::string(name, Span::unknown()),
-                    None => Value::nothing(Span::unknown())
+                    None => Value::nothing(Span::unknown()),
+
                 },
-                match author {
+                "author" => match author {
                     Some(author) => Value::string(author, Span::unknown()),
-                    None => Value::nothing(Span::unknown())
+                    None => Value::nothing(Span::unknown()),
                 },
-                Value::bool(default, Span::unknown()),
-            ],
-            Span::unknown()
+                "default" => Value::bool(default, Span::unknown()),
+            },
+            Span::unknown(),
         )
     }
 }
@@ -47,7 +42,7 @@ impl From<ListThemes> for Value {
     fn from(value: ListThemes) -> Self {
         Value::list(
             value.0.into_iter().map(Value::from).collect(),
-            Span::unknown()
+            Span::unknown(),
         )
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,7 +5,7 @@ pub struct ThemeDescription {
     pub id: String,
     pub name: Option<String>,
     pub author: Option<String>,
-    pub default: bool,
+    pub default: bool
 }
 
 /// List of theme descriptions.
@@ -17,7 +17,7 @@ impl From<ThemeDescription> for Value {
             id,
             name,
             author,
-            default,
+            default
         } = value;
         Value::record(
             record! {
@@ -33,7 +33,7 @@ impl From<ThemeDescription> for Value {
                 },
                 "default" => Value::bool(default, Span::unknown()),
             },
-            Span::unknown(),
+            Span::unknown()
         )
     }
 }
@@ -42,7 +42,7 @@ impl From<ListThemes> for Value {
     fn from(value: ListThemes) -> Self {
         Value::list(
             value.0.into_iter().map(Value::from).collect(),
-            Span::unknown(),
+            Span::unknown()
         )
     }
 }


### PR DESCRIPTION
This PR updates your plugin to support nushell 0.84.1 with it's new record api. I realize you may not accept this PR since it points to a development nushell version, but it could still be used to help you understand what changes need to be made to support that latest dev version of nushell.