### PR TITLE
Replacing the deprecated command `register` with `plugin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Follow these steps:
     plugin add path/to/the/plugin/binary
     ```
 
-5. Load plugin into scope:
+5. Make the plugin available for use:
+
+   Tip: You can simply restart the shell or terminal. When nushell starts, it loads all plugins.
 
    If you are using a version **lower** than **0.93.0**, you do **not need** to do this.
    ```nushell

--- a/README.md
+++ b/README.md
@@ -109,9 +109,18 @@ Follow these steps:
     ```
 
 4. Register the plugin with Nushell:
+   
+    If you are using a version **lower** than **0.93.0**, use `register` instead of `plugin add`.
     ```nushell
-    register path/to/the/plugin/binary
+    plugin add path/to/the/plugin/binary
     ```
+
+5. Load plugin into scope:
+
+   If you are using a version **lower** than **0.93.0**, you do **not need** to do this.
+   ```nushell
+   plugin use highlight
+   ```
 
 After registering, the plugin is available as part of your set of commands:
 


### PR DESCRIPTION
Although it is still working and will be removed only in the next major version as stated in the [changelog](https://www.nushell.sh/blog/2024-04-30-nushell_0_93_0.html#redesigned-plugin-management-commands-toc).
I think it's worth updating the README now, since this is inevitable and there's no point in postponing it.