### PR TITLE
Custom `.tmtheme` themes via `syntect::highlighting::ThemeSet::load_from_folder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "ansi_colours",
  "bat",
  "nu-ansi-term 0.50.0",
+ "nu-path",
  "nu-plugin",
  "nu-protocol",
  "syntect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities", "development-tools", "value-formatting"]
 # nu
 nu-plugin = { version = "0.94", path = "../nushell/crates/nu-plugin" }
 nu-protocol = { version = "0.94", path = "../nushell/crates/nu-protocol" }
+nu-path = { version = "0.94", path = "../nushell/crates/nu-path" }
 
 # highlighting
 syntect = "5"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ provides syntax highlighting for source code.
 It uses the [`syntect`](https://crates.io/crates/syntect) library for syntax 
 highlighting and the [`bat`](https://crates.io/crates/bat) library for easy 
 access to its ready-to-use assets.
+Custom themes can be loaded too.
 
 ## Usage
 The `highlight` command can be used for syntax highlighting source code. 
@@ -82,6 +83,14 @@ result in a single row with your selected theme.
 If you get no results, you have set an invalid theme.
 ```nushell
 $env.config.plugin.highlight.theme = ansi
+```
+
+### `custom_themes`
+Set a directory to load custom themes from.
+Using `synctect`s theme loader, you can load custom themes in the `.tmtheme` 
+format from a directory that is passed as this configuration value.
+```nushell
+$env.config.plugin.highlight.custom_themes = ~/.nu/highlight/themes
 ```
 
 ## Plugin Installation

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Set a directory to load custom themes from.
 Using `synctect`s theme loader, you can load custom themes in the `.tmtheme` 
 format from a directory that is passed as this configuration value.
 ```nushell
-$env.config.plugin.highlight.custom_themes = ~/.nu/highlight/themes
+$env.config.plugins.highlight.custom_themes = ~/.nu/highlight/themes
 ```
 
 ## Plugin Installation

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ variable.
 Enable or disable true colors (24-bit).
 By default, this is enabled.
 ```nushell
-$env.config.plugin.highlight.true_colors = true
+$env.config.plugins.highlight.true_colors = true
 ```
 
 ### `theme`
@@ -82,7 +82,7 @@ Setting this environment variable should allow
 result in a single row with your selected theme.
 If you get no results, you have set an invalid theme.
 ```nushell
-$env.config.plugin.highlight.theme = ansi
+$env.config.plugins.highlight.theme = ansi
 ```
 
 ### `custom_themes`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ highlight --list-themes
 
 ## Configuration
 The plugin can be configured using the 
-[`$env.config.plugin.highlight`](https://github.com/nushell/nushell/pull/10955) 
+[`$env.config.plugins.highlight`](https://github.com/nushell/nushell/pull/10955) 
 variable.
 
 ### `true_colors`
@@ -78,7 +78,7 @@ Set a theme to use.
 The default theme depends on the operating system.
 Use `highlight --list-themes | where default == true` to see your default theme.
 Setting this environment variable should allow
-`highlight --list-themes | where id == $env.config.plugin.highlight.theme` to 
+`highlight --list-themes | where id == $env.config.plugins.highlight.theme` to 
 result in a single row with your selected theme.
 If you get no results, you have set an invalid theme.
 ```nushell


### PR DESCRIPTION
This PR replaces #11's implementation idea by directly loading custom themes via `syntect::highlighting::ThemeSet::load_from_folder`. With only a few themes, this loading is fast enough to not be noticeable. This variant doesn't require any locally installed version of `bat` but still includes all themes that `bat` provides.

The implementation is tested using [catppuccin/bat](https://github.com/catppuccin/bat).

closes #10
closes #11 